### PR TITLE
- introduced coroutines version properties and dependencies

### DIFF
--- a/examples/coroutines/coroutines-1/pom.xml
+++ b/examples/coroutines/coroutines-1/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.examples.coroutines</groupId>
+        <artifactId>coroutines</artifactId>
+        <version>0.0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>coroutines-1</artifactId>
+
+    <name>coroutines-1</name>
+</project>

--- a/examples/coroutines/coroutines-1/src/main/kotlin/co/luminositylabs/examples/ExampleBasic01.kt
+++ b/examples/coroutines/coroutines-1/src/main/kotlin/co/luminositylabs/examples/ExampleBasic01.kt
@@ -1,0 +1,21 @@
+package co.luminositylabs.examples
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+fun main() = ExampleBasicNonBlocking().nonBlockingHelloWorld()
+
+@SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+class ExampleBasicNonBlocking {
+    fun nonBlockingHelloWorld() {
+        runBlocking { // this: CoroutinesScope
+            launch { // launch a new coroutine and continue
+                delay(1000L) // non-blocking delay for 1 second (default unit is ms)
+                println("World!") // printer after delay
+            }
+            println("Hello") // main coroutine continues while a previous one is delayed
+        }
+    }
+}

--- a/examples/coroutines/coroutines-1/src/test/kotlin/co/luminositylabs/examples/CoroutinesTest.kt
+++ b/examples/coroutines/coroutines-1/src/test/kotlin/co/luminositylabs/examples/CoroutinesTest.kt
@@ -1,0 +1,10 @@
+package co.luminositylabs.examples
+
+import kotlin.test.Test
+
+class CoroutinesTest {
+    @Test
+    fun `Coroutines Test`() {
+        main()
+    }
+}

--- a/examples/coroutines/pom.xml
+++ b/examples/coroutines/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.examples</groupId>
+        <artifactId>examples</artifactId>
+        <version>0.0.2-SNAPSHOT</version>
+    </parent>
+
+    <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.examples.coroutines</groupId>
+    <artifactId>coroutines</artifactId>
+    <packaging>pom</packaging>
+
+    <name>coroutines</name>
+    <description>Example code demonstrating Kotlin coroutines usage</description>
+
+    <modules>
+        <module>coroutines-1</module>
+    </modules>
+</project>

--- a/examples/gson-1/pom.xml
+++ b/examples/gson-1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.examples</groupId>
         <artifactId>examples</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>gson-1</artifactId>

--- a/examples/http4k-1/pom.xml
+++ b/examples/http4k-1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.examples</groupId>
         <artifactId>examples</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>http4k-1</artifactId>

--- a/examples/maven-version-rules.xml
+++ b/examples/maven-version-rules.xml
@@ -1,7 +1,6 @@
 <ruleset comparisonMethod="maven"
-         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 https://www.mojohaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+         xmlns="https://www.mojohaus.org/VERSIONS/RULE/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/2.1.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-2.1.0.xsd">
     <ignoreVersions>
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>

--- a/examples/moshi-1/pom.xml
+++ b/examples/moshi-1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.examples</groupId>
         <artifactId>examples</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>moshi-1</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,13 +10,13 @@
 
     <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.examples</groupId>
     <artifactId>examples</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>examples</name>
     <description>Example code aggregator module</description>
 
     <modules>
+        <module>coroutines</module>
         <module>gson-1</module>
         <module>http4k-1</module>
         <module>moshi-1</module>
@@ -34,7 +34,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.commonjava.maven.plugins</groupId>
+                    <groupId>com.github.hazendaz.maven</groupId>
                     <artifactId>directory-maven-plugin</artifactId>
                     <executions>
                         <execution>
@@ -72,7 +72,7 @@
         <plugins>
             <plugin>
                 <!-- This plugin must be declared prior to any other plugins using the multi.module.root property -->
-                <groupId>org.commonjava.maven.plugins</groupId>
+                <groupId>com.github.hazendaz.maven</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <dependency.http4k.version>5.13.7.0</dependency.http4k.version>
         <dependency.moshi.version>1.15.1</dependency.moshi.version>
         <dependency.ktlint.version>0.48.0</dependency.ktlint.version>
+        <dependency.kotlinx-coroutines.version>1.8.0</dependency.kotlinx-coroutines.version>
     </properties>
 
     <dependencyManagement>
@@ -85,6 +86,11 @@
                 <artifactId>kotlin-test-testng</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-core</artifactId>
+                <version>${dependency.kotlinx-coroutines.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -92,6 +98,10 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/testing/helloworld-1/pom.xml
+++ b/testing/helloworld-1/pom.xml
@@ -7,11 +7,10 @@
     <parent>
         <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.testing</groupId>
         <artifactId>testing</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>helloworld-1</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>helloworld-1</name>

--- a/testing/maven-version-rules.xml
+++ b/testing/maven-version-rules.xml
@@ -1,7 +1,6 @@
 <ruleset comparisonMethod="maven"
-         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 https://www.mojohaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+         xmlns="https://www.mojohaus.org/VERSIONS/RULE/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/2.1.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-2.1.0.xsd">
     <ignoreVersions>
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>co.luminositylabs.oss.luminositylabs-kotlin-base.testing</groupId>
     <artifactId>testing</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>testing</name>
@@ -32,7 +31,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.commonjava.maven.plugins</groupId>
+                    <groupId>com.github.hazendaz.maven</groupId>
                     <artifactId>directory-maven-plugin</artifactId>
                     <executions>
                         <execution>
@@ -70,7 +69,7 @@
         <plugins>
             <plugin>
                 <!-- This plugin must be declared prior to any other plugins using the multi.module.root property -->
-                <groupId>org.commonjava.maven.plugins</groupId>
+                <groupId>com.github.hazendaz.maven</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
             </plugin>
         </plugins>


### PR DESCRIPTION
- added a coroutines example module
- updated header for maven-version-rules.xml to latest namespace in testing module project
- switched directory-maven-plugin groupId from org.commonjava.maven.plugins to com.github.hazendaz.maven
- changed testing and examples projects to remove explicit version from artifacts and inherit from parents