### PR TITLE
Updates

### DIFF
--- a/examples/coroutines/coroutines-1/src/main/kotlin/co/luminositylabs/oss/examples/ExampleBasic01.kt
+++ b/examples/coroutines/coroutines-1/src/main/kotlin/co/luminositylabs/oss/examples/ExampleBasic01.kt
@@ -1,6 +1,5 @@
 package co.luminositylabs.oss.examples
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -10,7 +9,6 @@ val logger = KotlinLogging.logger {}
 
 fun main() = ExampleBasicNonBlocking().nonBlockingHelloWorld()
 
-@SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
 class ExampleBasicNonBlocking {
     fun nonBlockingHelloWorld() {
         runBlocking {

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
         <!-- dependency versioning -->
         <dependency.dokka.version>2.0.0</dependency.dokka.version>
         <dependency.gson.version>2.12.1</dependency.gson.version>
-        <dependency.http4k.version>6.0.0.0</dependency.http4k.version>
-        <dependency.jackson.version>2.18.2</dependency.jackson.version>
+        <dependency.http4k.version>6.0.1.0</dependency.http4k.version>
+        <dependency.jackson.version>2.18.3</dependency.jackson.version>
         <dependency.moshi.version>1.15.2</dependency.moshi.version>
         <dependency.ktlint.version>0.48.0</dependency.ktlint.version>
         <dependency.kotlin-logging-jvm.version>7.0.4</dependency.kotlin-logging-jvm.version>


### PR DESCRIPTION
- http4k updated from v6.0.0.0 to v6.0.1.0
- removed NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE suppression from ExampleBasic01.kt in coroutines-1 module as it is no longer necessary