### PR TITLE
Update http4k version rules to pin pre-V6 versions due to Java 21 requirement in V6+

### DIFF
--- a/examples/maven-version-rules.xml
+++ b/examples/maven-version-rules.xml
@@ -5,9 +5,10 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
+        <!-- Pin http4k version to pre-V6 (v6+ requires java 21) -->
         <rule groupId="org.http4k" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">6\..*</ignoreVersion>
+                <ignoreVersion type="regex">^(?:[6-9]|\d{2,})\..*$</ignoreVersion>
             </ignoreVersions>
         </rule>
     </rules>


### PR DESCRIPTION
Update http4k version rules to pin pre-V6 versions due to Java 21 requirement in V6+