### PR TITLE
branch maintenance Release/0.1.2.x - Updates (#421)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency.jackson3.version>3.1.3</dependency.jackson3.version>
         <dependency.moshi.version>1.15.2</dependency.moshi.version>
         <dependency.ktlint.version>0.48.0</dependency.ktlint.version>
-        <dependency.kotlin-logging-jvm.version>8.0.03</dependency.kotlin-logging-jvm.version>
+        <dependency.kotlin-logging-jvm.version>8.0.4</dependency.kotlin-logging-jvm.version>
         <dependency.kotlinx-coroutines.version>1.11.0</dependency.kotlinx-coroutines.version>
     </properties>
 


### PR DESCRIPTION
- kotlin-logging-jvm updated from v8.0.03 to v8.0.4