### PR TITLE
branch maintenance Release/0.1.1.x - Updates (#421)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency.jackson.version>2.20.2</dependency.jackson.version>
         <dependency.moshi.version>1.15.2</dependency.moshi.version>
         <dependency.ktlint.version>0.48.0</dependency.ktlint.version>
-        <dependency.kotlin-logging-jvm.version>8.0.03</dependency.kotlin-logging-jvm.version>
+        <dependency.kotlin-logging-jvm.version>8.0.4</dependency.kotlin-logging-jvm.version>
         <dependency.kotlinx-coroutines.version>1.9.0</dependency.kotlinx-coroutines.version>
     </properties>
 


### PR DESCRIPTION
- kotlin-logging-jvm updated from v8.0.03 to v8.0.4