### PR TITLE
Temporary updates to maven-version-rules.xml to ignore jackson v2.22

### DIFF
--- a/examples/maven-version-rules.xml
+++ b/examples/maven-version-rules.xml
@@ -5,5 +5,12 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
+        <!-- Pin jackson to v2.21.x (2.22.x deployment temporarily broken) -->
+        <rule groupId="com.fasterxml.jackson" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">^2\.(?:2[2-9]|[3-9]\d|[1-9]\d{2,})\..*</ignoreVersion> <!-- Ignore v2.22.x + -->
+                <ignoreVersion type="regex">^(?:[3-9]|[1-9]\d+)\..*$</ignoreVersion> <!-- Ignore v3.x.x + -->
+            </ignoreVersions>
+        </rule>
     </rules>
 </ruleset>

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -5,5 +5,12 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
+        <!-- Pin jackson to v2.21.x (2.22.x deployment temporarily broken) -->
+        <rule groupId="com.fasterxml.jackson" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">^2\.(?:2[2-9]|[3-9]\d|[1-9]\d{2,})\..*</ignoreVersion> <!-- Ignore v2.22.x + -->
+                <ignoreVersion type="regex">^(?:[3-9]|[1-9]\d+)\..*$</ignoreVersion> <!-- Ignore v3.x.x + -->
+            </ignoreVersions>
+        </rule>
     </rules>
 </ruleset>

--- a/testing/maven-version-rules.xml
+++ b/testing/maven-version-rules.xml
@@ -5,5 +5,12 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
+        <!-- Pin jackson to v2.21.x (2.22.x deployment temporarily broken) -->
+        <rule groupId="com.fasterxml.jackson" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">^2\.(?:2[2-9]|[3-9]\d|[1-9]\d{2,})\..*</ignoreVersion> <!-- Ignore v2.22.x + -->
+                <ignoreVersion type="regex">^(?:[3-9]|[1-9]\d+)\..*$</ignoreVersion> <!-- Ignore v3.x.x + -->
+            </ignoreVersions>
+        </rule>
     </rules>
 </ruleset>


### PR DESCRIPTION
Temporary updates to maven-version-rules.xml to ignore jackson v2.22.x until deployment is fixed