### PR TITLE
branch maintenance Release/0.3.2.x - Updates (#528)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
         jdk_version: [21.0.12-zulu, 25.0.4-zulu]
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             jdk_version: 21.0.12-zulu
             zulu_version: 21.52.15
             maven_deploy: true


### PR DESCRIPTION
- CI GHA runner os updated from ubuntu-24.04 to ubuntu-26.04